### PR TITLE
implement active patient info view with role-based display

### DIFF
--- a/sisyphus/src/app/trainer/page.tsx
+++ b/sisyphus/src/app/trainer/page.tsx
@@ -1,0 +1,35 @@
+import TrainerProfile from "@/components/trainer/TrainerProfile";
+import ActivePatientInfo from "@/components/trainer/ActivePatientInfo";
+
+type Role = "trainer" | "patient";
+
+interface TrainerDashboardProps {
+  role?: Role;
+}
+
+const TrainerDashboard = ({ role = "patient" }: TrainerDashboardProps) => {
+  return (
+    <main className="min-h-screen p-8 bg-white dark:bg-slate-900 text-slate-900 dark:text-white">
+      <h1 className="text-2xl font-bold mb-6">Trainer Dashboard</h1>
+      <TrainerProfile />
+
+      {role === "trainer" ? (
+        <ActivePatientInfo />
+      ) : (
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold text-white">Your Routine</h2>
+          <div className="bg-slate-800 p-4 rounded-lg text-white">
+            <p className="font-medium">🧘 Stretching - 10 mins</p>
+            <p className="font-medium">🏋️ Strength Training - 20 mins</p>
+            <p className="font-medium">🚴 Cardio - 15 mins</p>
+          </div>
+          <div className="text-sm text-slate-400">
+            Last updated: 2 hours ago
+          </div>
+        </div>
+      )}
+    </main>
+  );
+};
+
+export default TrainerDashboard;

--- a/sisyphus/src/components/trainer/ActivePatientInfo.tsx
+++ b/sisyphus/src/components/trainer/ActivePatientInfo.tsx
@@ -1,0 +1,19 @@
+const ActivePatientInfo = () => {
+  return (
+    <section className="bg-green-100 dark:bg-slate-800 rounded-xl p-6">
+      <h3 className="text-lg font-semibold mb-4">Active Patient</h3>
+      <div>
+        <p>
+          <strong>Name:</strong> Alex Morgan
+        </p>
+        <p>
+          <strong>Routine:</strong> Upper Body Strengthening
+        </p>
+        <p>
+          <strong>Progress:</strong> Completed 3 sessions, improved posture.
+        </p>
+      </div>
+    </section>
+  );
+};
+export default ActivePatientInfo;

--- a/sisyphus/src/components/trainer/TrainerProfile.tsx
+++ b/sisyphus/src/components/trainer/TrainerProfile.tsx
@@ -1,0 +1,12 @@
+const TrainerProfile = () => {
+  return (
+    <div className="bg-blue-100 dark:bg-slate-800 rounded-xl p-6 mb-8">
+      <h2 className="text-xl font-semibold">Dr. Lisa Reynolds</h2>
+      <p className="text-sm text-slate-600 dark:text-slate-300">
+        Physiotherapist
+      </p>
+    </div>
+  );
+};
+
+export default TrainerProfile;


### PR DESCRIPTION
This PR addresses [Issue #5](https://github.com/Sisyphus-Training/Sisyphus/issues/5):
"Display Active Patient Information Below Trainer's Profile"

Created a TrainerDashboard component that conditionally displays content based on user role (trainer or patient)

Integrated two views:
Trainer View: Displays trainer profile and mock active patient information (routine + metrics)
Patient View: Displays patient's own routine and mock progress data
All data is placeholder/mock for now, as backend functionality is not implemented yet
Used type Role = "trainer" | "patient" to safely toggle between modes
Ensured layout and structure are clean, responsive, and dark-mode compatible
Styled the section to align with the project’s theme (green, blue, white, and dark)

Notes
Currently role is hardcoded inside the TrainerDashboard for development testing (const role = "trainer" | "patient").
Designed the layout to support dynamic data later — e.g., real-time schedule updates, user sessions, etc.
All components are structured to easily integrate future backend logic and APIs